### PR TITLE
calculate-metrics: add wrong-filename script and refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ npm-debug.log
 check-pages*/
 
 # calculate-metrics.sh generates these files. Exception made for metrics.log since we want to commit it.
+/*.txt
 /*.log
 !metrics.log


### PR DESCRIPTION
I also refactored some functions, this enabled the option to only have one time (avoid duplicate code) check if a page exists we want to use.