### PR TITLE
calculate-metrics: simplify showing the missing TLDR pages

### DIFF
--- a/metrics.log
+++ b/metrics.log
@@ -1,6 +1,6 @@
 0 inconsistent filename(s) in check-pages/inconsistent-filenames.txt.
 0 malformed more info link page(s) in check-pages/malformed-more-info-link-pages.txt.
-0 missing TLDR page(s) in check-pages/missing-tldr-pages.txt.
+0 missing TLDR page(s) in check-pages/missing-tldr-commands.txt.
 0 misplaced page(s) in check-pages/misplaced-pages.txt.
 0 linter error(s) in check-pages/lint-errors.txt.
 ----------------------------------------------------------------------------------------------------
@@ -8,7 +8,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ar/malformed-or-outdated-more-info-link-ar-pages.txt.
 327 missing alias page(s) in check-pages.ar/missing-ar-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ar/mismatched-ar-page-titles.txt.
-13 missing TLDR page(s) in check-pages.ar/missing-tldr-ar-pages.txt.
+12 missing TLDR page(s) in check-pages.ar/missing-tldr-ar-commands.txt.
 0 misplaced page(s) in check-pages.ar/misplaced-ar-pages.txt.
 3 outdated page(s) based on number of commands in check-pages.ar/outdated-ar-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.ar/outdated-ar-pages-based-on-command-contents.txt.
@@ -20,7 +20,7 @@
 0 malformed or outdated more info link page(s) in check-pages.bn/malformed-or-outdated-more-info-link-bn-pages.txt.
 340 missing alias page(s) in check-pages.bn/missing-bn-alias-pages.txt.
 0 mismatched page title(s) in check-pages.bn/mismatched-bn-page-titles.txt.
-2 missing TLDR page(s) in check-pages.bn/missing-tldr-bn-pages.txt.
+2 missing TLDR page(s) in check-pages.bn/missing-tldr-bn-commands.txt.
 0 misplaced page(s) in check-pages.bn/misplaced-bn-pages.txt.
 7 outdated page(s) based on number of commands in check-pages.bn/outdated-bn-pages-based-on-command-count.txt.
 4 outdated page(s) based on the commands itself in check-pages.bn/outdated-bn-pages-based-on-command-contents.txt.
@@ -32,7 +32,7 @@
 0 malformed or outdated more info link page(s) in check-pages.bs/malformed-or-outdated-more-info-link-bs-pages.txt.
 308 missing alias page(s) in check-pages.bs/missing-bs-alias-pages.txt.
 0 mismatched page title(s) in check-pages.bs/mismatched-bs-page-titles.txt.
-33 missing TLDR page(s) in check-pages.bs/missing-tldr-bs-pages.txt.
+31 missing TLDR page(s) in check-pages.bs/missing-tldr-bs-commands.txt.
 0 misplaced page(s) in check-pages.bs/misplaced-bs-pages.txt.
 5 outdated page(s) based on number of commands in check-pages.bs/outdated-bs-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.bs/outdated-bs-pages-based-on-command-contents.txt.
@@ -44,7 +44,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ca/malformed-or-outdated-more-info-link-ca-pages.txt.
 324 missing alias page(s) in check-pages.ca/missing-ca-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ca/mismatched-ca-page-titles.txt.
-17 missing TLDR page(s) in check-pages.ca/missing-tldr-ca-pages.txt.
+16 missing TLDR page(s) in check-pages.ca/missing-tldr-ca-commands.txt.
 0 misplaced page(s) in check-pages.ca/misplaced-ca-pages.txt.
 14 outdated page(s) based on number of commands in check-pages.ca/outdated-ca-pages-based-on-command-count.txt.
 5 outdated page(s) based on the commands itself in check-pages.ca/outdated-ca-pages-based-on-command-contents.txt.
@@ -56,7 +56,7 @@
 0 malformed or outdated more info link page(s) in check-pages.cs/malformed-or-outdated-more-info-link-cs-pages.txt.
 342 missing alias page(s) in check-pages.cs/missing-cs-alias-pages.txt.
 0 mismatched page title(s) in check-pages.cs/mismatched-cs-page-titles.txt.
-0 missing TLDR page(s) in check-pages.cs/missing-tldr-cs-pages.txt.
+0 missing TLDR page(s) in check-pages.cs/missing-tldr-cs-commands.txt.
 0 misplaced page(s) in check-pages.cs/misplaced-cs-pages.txt.
 1 outdated page(s) based on number of commands in check-pages.cs/outdated-cs-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.cs/outdated-cs-pages-based-on-command-contents.txt.
@@ -68,7 +68,7 @@
 0 malformed or outdated more info link page(s) in check-pages.da/malformed-or-outdated-more-info-link-da-pages.txt.
 327 missing alias page(s) in check-pages.da/missing-da-alias-pages.txt.
 0 mismatched page title(s) in check-pages.da/mismatched-da-page-titles.txt.
-13 missing TLDR page(s) in check-pages.da/missing-tldr-da-pages.txt.
+12 missing TLDR page(s) in check-pages.da/missing-tldr-da-commands.txt.
 0 misplaced page(s) in check-pages.da/misplaced-da-pages.txt.
 7 outdated page(s) based on number of commands in check-pages.da/outdated-da-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.da/outdated-da-pages-based-on-command-contents.txt.
@@ -80,7 +80,7 @@
 1 malformed or outdated more info link page(s) in check-pages.de/malformed-or-outdated-more-info-link-de-pages.txt.
 139 missing alias page(s) in check-pages.de/missing-de-alias-pages.txt.
 0 mismatched page title(s) in check-pages.de/mismatched-de-page-titles.txt.
-161 missing TLDR page(s) in check-pages.de/missing-tldr-de-pages.txt.
+153 missing TLDR page(s) in check-pages.de/missing-tldr-de-commands.txt.
 0 misplaced page(s) in check-pages.de/misplaced-de-pages.txt.
 81 outdated page(s) based on number of commands in check-pages.de/outdated-de-pages-based-on-command-count.txt.
 23 outdated page(s) based on the commands itself in check-pages.de/outdated-de-pages-based-on-command-contents.txt.
@@ -92,7 +92,7 @@
 0 malformed or outdated more info link page(s) in check-pages.es/malformed-or-outdated-more-info-link-es-pages.txt.
 116 missing alias page(s) in check-pages.es/missing-es-alias-pages.txt.
 0 mismatched page title(s) in check-pages.es/mismatched-es-page-titles.txt.
-173 missing TLDR page(s) in check-pages.es/missing-tldr-es-pages.txt.
+163 missing TLDR page(s) in check-pages.es/missing-tldr-es-commands.txt.
 0 misplaced page(s) in check-pages.es/misplaced-es-pages.txt.
 64 outdated page(s) based on number of commands in check-pages.es/outdated-es-pages-based-on-command-count.txt.
 18 outdated page(s) based on the commands itself in check-pages.es/outdated-es-pages-based-on-command-contents.txt.
@@ -104,7 +104,7 @@
 0 malformed or outdated more info link page(s) in check-pages.fa/malformed-or-outdated-more-info-link-fa-pages.txt.
 342 missing alias page(s) in check-pages.fa/missing-fa-alias-pages.txt.
 0 mismatched page title(s) in check-pages.fa/mismatched-fa-page-titles.txt.
-0 missing TLDR page(s) in check-pages.fa/missing-tldr-fa-pages.txt.
+0 missing TLDR page(s) in check-pages.fa/missing-tldr-fa-commands.txt.
 0 misplaced page(s) in check-pages.fa/misplaced-fa-pages.txt.
 16 outdated page(s) based on number of commands in check-pages.fa/outdated-fa-pages-based-on-command-count.txt.
 6 outdated page(s) based on the commands itself in check-pages.fa/outdated-fa-pages-based-on-command-contents.txt.
@@ -116,7 +116,7 @@
 0 malformed or outdated more info link page(s) in check-pages.fi/malformed-or-outdated-more-info-link-fi-pages.txt.
 342 missing alias page(s) in check-pages.fi/missing-fi-alias-pages.txt.
 0 mismatched page title(s) in check-pages.fi/mismatched-fi-page-titles.txt.
-0 missing TLDR page(s) in check-pages.fi/missing-tldr-fi-pages.txt.
+0 missing TLDR page(s) in check-pages.fi/missing-tldr-fi-commands.txt.
 0 misplaced page(s) in check-pages.fi/misplaced-fi-pages.txt.
 0 outdated page(s) based on number of commands in check-pages.fi/outdated-fi-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.fi/outdated-fi-pages-based-on-command-contents.txt.
@@ -128,7 +128,7 @@
 0 malformed or outdated more info link page(s) in check-pages.fr/malformed-or-outdated-more-info-link-fr-pages.txt.
 138 missing alias page(s) in check-pages.fr/missing-fr-alias-pages.txt.
 0 mismatched page title(s) in check-pages.fr/mismatched-fr-page-titles.txt.
-159 missing TLDR page(s) in check-pages.fr/missing-tldr-fr-pages.txt.
+151 missing TLDR page(s) in check-pages.fr/missing-tldr-fr-commands.txt.
 0 misplaced page(s) in check-pages.fr/misplaced-fr-pages.txt.
 94 outdated page(s) based on number of commands in check-pages.fr/outdated-fr-pages-based-on-command-count.txt.
 36 outdated page(s) based on the commands itself in check-pages.fr/outdated-fr-pages-based-on-command-contents.txt.
@@ -140,7 +140,7 @@
 0 malformed or outdated more info link page(s) in check-pages.hi/malformed-or-outdated-more-info-link-hi-pages.txt.
 140 missing alias page(s) in check-pages.hi/missing-hi-alias-pages.txt.
 0 mismatched page title(s) in check-pages.hi/mismatched-hi-page-titles.txt.
-183 missing TLDR page(s) in check-pages.hi/missing-tldr-hi-pages.txt.
+175 missing TLDR page(s) in check-pages.hi/missing-tldr-hi-commands.txt.
 0 misplaced page(s) in check-pages.hi/misplaced-hi-pages.txt.
 23 outdated page(s) based on number of commands in check-pages.hi/outdated-hi-pages-based-on-command-count.txt.
 8 outdated page(s) based on the commands itself in check-pages.hi/outdated-hi-pages-based-on-command-contents.txt.
@@ -152,7 +152,7 @@
 0 malformed or outdated more info link page(s) in check-pages.id/malformed-or-outdated-more-info-link-id-pages.txt.
 135 missing alias page(s) in check-pages.id/missing-id-alias-pages.txt.
 0 mismatched page title(s) in check-pages.id/mismatched-id-page-titles.txt.
-175 missing TLDR page(s) in check-pages.id/missing-tldr-id-pages.txt.
+166 missing TLDR page(s) in check-pages.id/missing-tldr-id-commands.txt.
 0 misplaced page(s) in check-pages.id/misplaced-id-pages.txt.
 33 outdated page(s) based on number of commands in check-pages.id/outdated-id-pages-based-on-command-count.txt.
 19 outdated page(s) based on the commands itself in check-pages.id/outdated-id-pages-based-on-command-contents.txt.
@@ -164,7 +164,7 @@
 0 malformed or outdated more info link page(s) in check-pages.it/malformed-or-outdated-more-info-link-it-pages.txt.
 139 missing alias page(s) in check-pages.it/missing-it-alias-pages.txt.
 0 mismatched page title(s) in check-pages.it/mismatched-it-page-titles.txt.
-151 missing TLDR page(s) in check-pages.it/missing-tldr-it-pages.txt.
+143 missing TLDR page(s) in check-pages.it/missing-tldr-it-commands.txt.
 0 misplaced page(s) in check-pages.it/misplaced-it-pages.txt.
 138 outdated page(s) based on number of commands in check-pages.it/outdated-it-pages-based-on-command-count.txt.
 34 outdated page(s) based on the commands itself in check-pages.it/outdated-it-pages-based-on-command-contents.txt.
@@ -176,7 +176,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ja/malformed-or-outdated-more-info-link-ja-pages.txt.
 308 missing alias page(s) in check-pages.ja/missing-ja-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ja/mismatched-ja-page-titles.txt.
-31 missing TLDR page(s) in check-pages.ja/missing-tldr-ja-pages.txt.
+29 missing TLDR page(s) in check-pages.ja/missing-tldr-ja-commands.txt.
 0 misplaced page(s) in check-pages.ja/misplaced-ja-pages.txt.
 30 outdated page(s) based on number of commands in check-pages.ja/outdated-ja-pages-based-on-command-count.txt.
 4 outdated page(s) based on the commands itself in check-pages.ja/outdated-ja-pages-based-on-command-contents.txt.
@@ -188,7 +188,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ko/malformed-or-outdated-more-info-link-ko-pages.txt.
 130 missing alias page(s) in check-pages.ko/missing-ko-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ko/mismatched-ko-page-titles.txt.
-148 missing TLDR page(s) in check-pages.ko/missing-tldr-ko-pages.txt.
+142 missing TLDR page(s) in check-pages.ko/missing-tldr-ko-commands.txt.
 0 misplaced page(s) in check-pages.ko/misplaced-ko-pages.txt.
 68 outdated page(s) based on number of commands in check-pages.ko/outdated-ko-pages-based-on-command-count.txt.
 44 outdated page(s) based on the commands itself in check-pages.ko/outdated-ko-pages-based-on-command-contents.txt.
@@ -200,7 +200,7 @@
 0 malformed or outdated more info link page(s) in check-pages.lo/malformed-or-outdated-more-info-link-lo-pages.txt.
 307 missing alias page(s) in check-pages.lo/missing-lo-alias-pages.txt.
 0 mismatched page title(s) in check-pages.lo/mismatched-lo-page-titles.txt.
-33 missing TLDR page(s) in check-pages.lo/missing-tldr-lo-pages.txt.
+31 missing TLDR page(s) in check-pages.lo/missing-tldr-lo-commands.txt.
 0 misplaced page(s) in check-pages.lo/misplaced-lo-pages.txt.
 5 outdated page(s) based on number of commands in check-pages.lo/outdated-lo-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.lo/outdated-lo-pages-based-on-command-contents.txt.
@@ -212,7 +212,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ml/malformed-or-outdated-more-info-link-ml-pages.txt.
 308 missing alias page(s) in check-pages.ml/missing-ml-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ml/mismatched-ml-page-titles.txt.
-31 missing TLDR page(s) in check-pages.ml/missing-tldr-ml-pages.txt.
+29 missing TLDR page(s) in check-pages.ml/missing-tldr-ml-commands.txt.
 0 misplaced page(s) in check-pages.ml/misplaced-ml-pages.txt.
 11 outdated page(s) based on number of commands in check-pages.ml/outdated-ml-pages-based-on-command-count.txt.
 1 outdated page(s) based on the commands itself in check-pages.ml/outdated-ml-pages-based-on-command-contents.txt.
@@ -224,7 +224,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ne/malformed-or-outdated-more-info-link-ne-pages.txt.
 300 missing alias page(s) in check-pages.ne/missing-ne-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ne/mismatched-ne-page-titles.txt.
-41 missing TLDR page(s) in check-pages.ne/missing-tldr-ne-pages.txt.
+35 missing TLDR page(s) in check-pages.ne/missing-tldr-ne-commands.txt.
 0 misplaced page(s) in check-pages.ne/misplaced-ne-pages.txt.
 9 outdated page(s) based on number of commands in check-pages.ne/outdated-ne-pages-based-on-command-count.txt.
 4 outdated page(s) based on the commands itself in check-pages.ne/outdated-ne-pages-based-on-command-contents.txt.
@@ -236,7 +236,7 @@
 0 malformed or outdated more info link page(s) in check-pages.nl/malformed-or-outdated-more-info-link-nl-pages.txt.
 0 missing alias page(s) in check-pages.nl/missing-nl-alias-pages.txt.
 0 mismatched page title(s) in check-pages.nl/mismatched-nl-page-titles.txt.
-0 missing TLDR page(s) in check-pages.nl/missing-tldr-nl-pages.txt.
+0 missing TLDR page(s) in check-pages.nl/missing-tldr-nl-commands.txt.
 0 misplaced page(s) in check-pages.nl/misplaced-nl-pages.txt.
 0 outdated page(s) based on number of commands in check-pages.nl/outdated-nl-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.nl/outdated-nl-pages-based-on-command-contents.txt.
@@ -248,7 +248,7 @@
 0 malformed or outdated more info link page(s) in check-pages.no/malformed-or-outdated-more-info-link-no-pages.txt.
 308 missing alias page(s) in check-pages.no/missing-no-alias-pages.txt.
 0 mismatched page title(s) in check-pages.no/mismatched-no-page-titles.txt.
-32 missing TLDR page(s) in check-pages.no/missing-tldr-no-pages.txt.
+30 missing TLDR page(s) in check-pages.no/missing-tldr-no-commands.txt.
 0 misplaced page(s) in check-pages.no/misplaced-no-pages.txt.
 6 outdated page(s) based on number of commands in check-pages.no/outdated-no-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.no/outdated-no-pages-based-on-command-contents.txt.
@@ -260,7 +260,7 @@
 1 malformed or outdated more info link page(s) in check-pages.pl/malformed-or-outdated-more-info-link-pl-pages.txt.
 99 missing alias page(s) in check-pages.pl/missing-pl-alias-pages.txt.
 0 mismatched page title(s) in check-pages.pl/mismatched-pl-page-titles.txt.
-226 missing TLDR page(s) in check-pages.pl/missing-tldr-pl-pages.txt.
+208 missing TLDR page(s) in check-pages.pl/missing-tldr-pl-commands.txt.
 0 misplaced page(s) in check-pages.pl/misplaced-pl-pages.txt.
 31 outdated page(s) based on number of commands in check-pages.pl/outdated-pl-pages-based-on-command-count.txt.
 5 outdated page(s) based on the commands itself in check-pages.pl/outdated-pl-pages-based-on-command-contents.txt.
@@ -272,7 +272,7 @@
 0 malformed or outdated more info link page(s) in check-pages.pt_BR/malformed-or-outdated-more-info-link-pt_BR-pages.txt.
 139 missing alias page(s) in check-pages.pt_BR/missing-pt_BR-alias-pages.txt.
 0 mismatched page title(s) in check-pages.pt_BR/mismatched-pt_BR-page-titles.txt.
-150 missing TLDR page(s) in check-pages.pt_BR/missing-tldr-pt_BR-pages.txt.
+147 missing TLDR page(s) in check-pages.pt_BR/missing-tldr-pt_BR-commands.txt.
 0 misplaced page(s) in check-pages.pt_BR/misplaced-pt_BR-pages.txt.
 76 outdated page(s) based on number of commands in check-pages.pt_BR/outdated-pt_BR-pages-based-on-command-count.txt.
 41 outdated page(s) based on the commands itself in check-pages.pt_BR/outdated-pt_BR-pages-based-on-command-contents.txt.
@@ -284,7 +284,7 @@
 0 malformed or outdated more info link page(s) in check-pages.pt_PT/malformed-or-outdated-more-info-link-pt_PT-pages.txt.
 140 missing alias page(s) in check-pages.pt_PT/missing-pt_PT-alias-pages.txt.
 0 mismatched page title(s) in check-pages.pt_PT/mismatched-pt_PT-page-titles.txt.
-198 missing TLDR page(s) in check-pages.pt_PT/missing-tldr-pt_PT-pages.txt.
+189 missing TLDR page(s) in check-pages.pt_PT/missing-tldr-pt_PT-commands.txt.
 0 misplaced page(s) in check-pages.pt_PT/misplaced-pt_PT-pages.txt.
 21 outdated page(s) based on number of commands in check-pages.pt_PT/outdated-pt_PT-pages-based-on-command-count.txt.
 6 outdated page(s) based on the commands itself in check-pages.pt_PT/outdated-pt_PT-pages-based-on-command-contents.txt.
@@ -296,7 +296,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ro/malformed-or-outdated-more-info-link-ro-pages.txt.
 342 missing alias page(s) in check-pages.ro/missing-ro-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ro/mismatched-ro-page-titles.txt.
-0 missing TLDR page(s) in check-pages.ro/missing-tldr-ro-pages.txt.
+0 missing TLDR page(s) in check-pages.ro/missing-tldr-ro-commands.txt.
 0 misplaced page(s) in check-pages.ro/misplaced-ro-pages.txt.
 0 outdated page(s) based on number of commands in check-pages.ro/outdated-ro-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.ro/outdated-ro-pages-based-on-command-contents.txt.
@@ -308,7 +308,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ru/malformed-or-outdated-more-info-link-ru-pages.txt.
 308 missing alias page(s) in check-pages.ru/missing-ru-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ru/mismatched-ru-page-titles.txt.
-32 missing TLDR page(s) in check-pages.ru/missing-tldr-ru-pages.txt.
+30 missing TLDR page(s) in check-pages.ru/missing-tldr-ru-commands.txt.
 0 misplaced page(s) in check-pages.ru/misplaced-ru-pages.txt.
 25 outdated page(s) based on number of commands in check-pages.ru/outdated-ru-pages-based-on-command-count.txt.
 6 outdated page(s) based on the commands itself in check-pages.ru/outdated-ru-pages-based-on-command-contents.txt.
@@ -320,7 +320,7 @@
 0 malformed or outdated more info link page(s) in check-pages.sh/malformed-or-outdated-more-info-link-sh-pages.txt.
 0 missing alias page(s) in check-pages.sh/missing-sh-alias-pages.txt.
 0 mismatched page title(s) in check-pages.sh/mismatched-sh-page-titles.txt.
-0 missing TLDR page(s) in check-pages.sh/missing-tldr-sh-pages.txt.
+0 missing TLDR page(s) in check-pages.sh/missing-tldr-sh-commands.txt.
 0 misplaced page(s) in check-pages.sh/misplaced-sh-pages.txt.
 8 outdated page(s) based on number of commands in check-pages.sh/outdated-sh-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.sh/outdated-sh-pages-based-on-command-contents.txt.
@@ -332,7 +332,7 @@
 0 malformed or outdated more info link page(s) in check-pages.sr/malformed-or-outdated-more-info-link-sr-pages.txt.
 342 missing alias page(s) in check-pages.sr/missing-sr-alias-pages.txt.
 0 mismatched page title(s) in check-pages.sr/mismatched-sr-page-titles.txt.
-0 missing TLDR page(s) in check-pages.sr/missing-tldr-sr-pages.txt.
+0 missing TLDR page(s) in check-pages.sr/missing-tldr-sr-commands.txt.
 0 misplaced page(s) in check-pages.sr/misplaced-sr-pages.txt.
 3 outdated page(s) based on number of commands in check-pages.sr/outdated-sr-pages-based-on-command-count.txt.
 1 outdated page(s) based on the commands itself in check-pages.sr/outdated-sr-pages-based-on-command-contents.txt.
@@ -344,7 +344,7 @@
 0 malformed or outdated more info link page(s) in check-pages.sv/malformed-or-outdated-more-info-link-sv-pages.txt.
 308 missing alias page(s) in check-pages.sv/missing-sv-alias-pages.txt.
 0 mismatched page title(s) in check-pages.sv/mismatched-sv-page-titles.txt.
-32 missing TLDR page(s) in check-pages.sv/missing-tldr-sv-pages.txt.
+30 missing TLDR page(s) in check-pages.sv/missing-tldr-sv-commands.txt.
 0 misplaced page(s) in check-pages.sv/misplaced-sv-pages.txt.
 11 outdated page(s) based on number of commands in check-pages.sv/outdated-sv-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.sv/outdated-sv-pages-based-on-command-contents.txt.
@@ -356,7 +356,7 @@
 0 malformed or outdated more info link page(s) in check-pages.ta/malformed-or-outdated-more-info-link-ta-pages.txt.
 134 missing alias page(s) in check-pages.ta/missing-ta-alias-pages.txt.
 0 mismatched page title(s) in check-pages.ta/mismatched-ta-page-titles.txt.
-195 missing TLDR page(s) in check-pages.ta/missing-tldr-ta-pages.txt.
+183 missing TLDR page(s) in check-pages.ta/missing-tldr-ta-commands.txt.
 0 misplaced page(s) in check-pages.ta/misplaced-ta-pages.txt.
 8 outdated page(s) based on number of commands in check-pages.ta/outdated-ta-pages-based-on-command-count.txt.
 15 outdated page(s) based on the commands itself in check-pages.ta/outdated-ta-pages-based-on-command-contents.txt.
@@ -368,7 +368,7 @@
 0 malformed or outdated more info link page(s) in check-pages.th/malformed-or-outdated-more-info-link-th-pages.txt.
 140 missing alias page(s) in check-pages.th/missing-th-alias-pages.txt.
 0 mismatched page title(s) in check-pages.th/mismatched-th-page-titles.txt.
-197 missing TLDR page(s) in check-pages.th/missing-tldr-th-pages.txt.
+188 missing TLDR page(s) in check-pages.th/missing-tldr-th-commands.txt.
 0 misplaced page(s) in check-pages.th/misplaced-th-pages.txt.
 11 outdated page(s) based on number of commands in check-pages.th/outdated-th-pages-based-on-command-count.txt.
 2 outdated page(s) based on the commands itself in check-pages.th/outdated-th-pages-based-on-command-contents.txt.
@@ -380,7 +380,7 @@
 0 malformed or outdated more info link page(s) in check-pages.tr/malformed-or-outdated-more-info-link-tr-pages.txt.
 139 missing alias page(s) in check-pages.tr/missing-tr-alias-pages.txt.
 0 mismatched page title(s) in check-pages.tr/mismatched-tr-page-titles.txt.
-185 missing TLDR page(s) in check-pages.tr/missing-tldr-tr-pages.txt.
+176 missing TLDR page(s) in check-pages.tr/missing-tldr-tr-commands.txt.
 0 misplaced page(s) in check-pages.tr/misplaced-tr-pages.txt.
 58 outdated page(s) based on number of commands in check-pages.tr/outdated-tr-pages-based-on-command-count.txt.
 20 outdated page(s) based on the commands itself in check-pages.tr/outdated-tr-pages-based-on-command-contents.txt.
@@ -392,7 +392,7 @@
 0 malformed or outdated more info link page(s) in check-pages.uk/malformed-or-outdated-more-info-link-uk-pages.txt.
 308 missing alias page(s) in check-pages.uk/missing-uk-alias-pages.txt.
 0 mismatched page title(s) in check-pages.uk/mismatched-uk-page-titles.txt.
-31 missing TLDR page(s) in check-pages.uk/missing-tldr-uk-pages.txt.
+29 missing TLDR page(s) in check-pages.uk/missing-tldr-uk-commands.txt.
 0 misplaced page(s) in check-pages.uk/misplaced-uk-pages.txt.
 14 outdated page(s) based on number of commands in check-pages.uk/outdated-uk-pages-based-on-command-count.txt.
 5 outdated page(s) based on the commands itself in check-pages.uk/outdated-uk-pages-based-on-command-contents.txt.
@@ -404,7 +404,7 @@
 0 malformed or outdated more info link page(s) in check-pages.uz/malformed-or-outdated-more-info-link-uz-pages.txt.
 342 missing alias page(s) in check-pages.uz/missing-uz-alias-pages.txt.
 0 mismatched page title(s) in check-pages.uz/mismatched-uz-page-titles.txt.
-0 missing TLDR page(s) in check-pages.uz/missing-tldr-uz-pages.txt.
+0 missing TLDR page(s) in check-pages.uz/missing-tldr-uz-commands.txt.
 0 misplaced page(s) in check-pages.uz/misplaced-uz-pages.txt.
 0 outdated page(s) based on number of commands in check-pages.uz/outdated-uz-pages-based-on-command-count.txt.
 0 outdated page(s) based on the commands itself in check-pages.uz/outdated-uz-pages-based-on-command-contents.txt.
@@ -416,7 +416,7 @@
 0 malformed or outdated more info link page(s) in check-pages.zh/malformed-or-outdated-more-info-link-zh-pages.txt.
 140 missing alias page(s) in check-pages.zh/missing-zh-alias-pages.txt.
 0 mismatched page title(s) in check-pages.zh/mismatched-zh-page-titles.txt.
-136 missing TLDR page(s) in check-pages.zh/missing-tldr-zh-pages.txt.
+132 missing TLDR page(s) in check-pages.zh/missing-tldr-zh-commands.txt.
 0 misplaced page(s) in check-pages.zh/misplaced-zh-pages.txt.
 116 outdated page(s) based on number of commands in check-pages.zh/outdated-zh-pages-based-on-command-count.txt.
 30 outdated page(s) based on the commands itself in check-pages.zh/outdated-zh-pages-based-on-command-contents.txt.
@@ -428,7 +428,7 @@
 0 malformed or outdated more info link page(s) in check-pages.zh_TW/malformed-or-outdated-more-info-link-zh_TW-pages.txt.
 140 missing alias page(s) in check-pages.zh_TW/missing-zh_TW-alias-pages.txt.
 0 mismatched page title(s) in check-pages.zh_TW/mismatched-zh_TW-page-titles.txt.
-181 missing TLDR page(s) in check-pages.zh_TW/missing-tldr-zh_TW-pages.txt.
+173 missing TLDR page(s) in check-pages.zh_TW/missing-tldr-zh_TW-commands.txt.
 0 misplaced page(s) in check-pages.zh_TW/misplaced-zh_TW-pages.txt.
 35 outdated page(s) based on number of commands in check-pages.zh_TW/outdated-zh_TW-pages-based-on-command-count.txt.
 6 outdated page(s) based on the commands itself in check-pages.zh_TW/outdated-zh_TW-pages-based-on-command-contents.txt.
@@ -436,25 +436,14 @@
 4793 missing translated page(s) in check-pages.zh_TW/missing-translated-zh_TW-pages.txt.
 0 linter error(s) in check-pages.zh_TW/lint-errors-zh_TW.txt.
 ----------------------------------------------------------------------------------------------------
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total inconsistent filename(s): 0/14979 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total malformed or outdated more info link page(s): 2/14979 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total missing alias page(s): 8141
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total mismatched page title(s): 0/2450 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
-Total missing TLDR page(s): 0/4520 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
+Total missing TLDR commands: 262/418 - 62%
 Total misplaced page(s): 0/14979 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total outdated page(s) based on number of commands: 1032/9905 - 10%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total outdated page(s) based on the commands itself: 343/9905 - 3%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total missing English page(s): 0/2450 - 0%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total missing translated page(s): 172759/182664 - 94%
-./scripts/calculate-metrics.sh: line 103: uniqify_file: command not found
 Total lint error(s): 0


### PR DESCRIPTION
A TLDR page is page that is being referenced to; like https://github.com/tldr-pages/tldr/blob/523b787bf953f80c0d12d999f9c3de0bb1dde35f/pages/linux/apx.md?plain=1#L8

This might generate some duplicates (if two pages reference the same; e.g. `tldr ls` in page-a and `tldr ls` in page-b, but it now shows where the `tldr …` can be found, which makes fixing it easier.