### PR TITLE
check-links.yml: remove verbose option

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -47,7 +47,6 @@ jobs:
           jobSummary: false
           args: >-
             --cache
-            --verbose
             --no-progress
             --accept 100..=103,200..=299,429
             --max-concurrency 25


### PR DESCRIPTION
At least on my PC, taking the first 1000 links from `grep -rh "More information: " pages/ | sort -u > test` and giving it to lychee with `lychee --cache --no-progress --accept 100..=103,200..=299,429 --max-concurrency 25 --exclude-all-private test` removes the unnecessary [200] reports.