### PR TITLE
scripts/check-pages.sh: detect and compare option placeholders

### DIFF
--- a/scripts/check-pages.sh
+++ b/scripts/check-pages.sh
@@ -122,12 +122,14 @@ strip_commands() {
 
   mapfile -t stripped_commands < <(
     grep "$COMMAND_REGEX" "$file" |
+    sed 's/{{\[\([^|]*|[^]]*\)\]}}/___\1___/g' |
     sed -E 's/\{\{([^}]|(\{[^}]*\}))*\}\}/{{}}/g' |
     sed 's/<[^>]*>//g' |
     sed 's/([^)]*)//g' |
     sed 's/"[^"]*"/""/g' |
     sed "s/'[^']*'//g" |
-    sed 's/`//g'
+    sed 's/`//g' |
+    sed 's/___\(.*\)___/{{\[\1\]}}/g'
   )
 
   printf "%s\n" "${stripped_commands[*]}"


### PR DESCRIPTION
Sister PR to https://github.com/tldr-pages/tldr/pull/20182

This one I'm fairly certain I got to work. I ran `scripts/check-pages.sh -l es` two times, on with and one without the patch and got this outcome

```
$ diff outdated-es-pages-based-on-command-contents-without-patch.txt outdated-es-pages-based-on-command-contents-with-patch.txt 
1a2
> pages.es/common/ani-cli.md
2a4,5
> pages.es/common/ansible-playbook.md
> pages.es/common/ansible-pull.md
50a54
> pages.es/common/gcc.md
63a68
> pages.es/common/gpg.md
72a78
> pages.es/common/img2sixel.md
81a88
> pages.es/common/ls.md
84a92
> pages.es/common/make.md
105a114
> pages.es/common/npm.md
196a206
> pages.es/linux/eu-readelf.md
236a247
> pages.es/linux/proctl.md
```