### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/calculate-metrics.yml
+++ b/.github/workflows/calculate-metrics.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   calculate-metrics:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
 
     name: Calculate Metrics
 


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/22](https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/22)

In general, the problem is fixed by adding an explicit `permissions` block to the workflow or to the specific job so that the `GITHUB_TOKEN` only has the minimal scopes needed. This documents the workflow’s needs and prevents it from inheriting overly broad defaults from the repository/organization.

For this workflow, we should add a `permissions` block under the `calculate-metrics` job (or at the root). The job uses `GITHUB_TOKEN` for:
- `actions/checkout` (requires `contents: read`).
- `mknejp/delete-release-assets` and `softprops/action-gh-release` (require `contents: write` to modify releases/assets).
- Python scripts that update dashboard issues (likely require `issues: write`).

To avoid breaking existing behavior, we should allow the necessary write scopes: `contents: write` and `issues: write`. We can add `permissions:` directly under the job definition (right after `runs-on: ubuntu-latest` and before `name: Calculate Metrics`) so that it applies to this job only. No imports or additional methods are required since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
