### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/21](https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/21)

In general, fix this by explicitly specifying minimal `GITHUB_TOKEN` permissions for the workflow or for individual jobs, instead of relying on inherited repository/organization defaults. For a lint-only workflow that just checks out code and installs/runs tools, `contents: read` is typically sufficient.

For this specific `lint` job in `.github/workflows/lint.yml`, the best change without altering functionality is to add a `permissions:` block scoped to the job, directly under `runs-on: ubuntu-latest`. This block should grant only read access to repository contents. No steps in this job require write permissions to GitHub resources (they operate locally within the runner), so `contents: read` is adequate. Concretely, modify the YAML to insert:

```yaml
permissions:
  contents: read
```

at lines 12–13 (after `runs-on: ubuntu-latest` and before `steps:`). No additional methods, imports, or external definitions are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
