### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-submodule.yml
+++ b/.github/workflows/update-submodule.yml
@@ -1,5 +1,9 @@
 name: Update Submodule
 
+permissions:
+  contents: write
+  actions: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/20](https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/20)

In general, fix this by adding a `permissions` section to the workflow or the specific job, granting only the scopes that are actually needed. For this workflow, the job must (a) push commits to the repository and (b) dispatch another workflow. That requires `contents: write` (to push commits) and `actions: write` (to call `github.rest.actions.createWorkflowDispatch`). No other scopes appear necessary from the snippet.

The best minimally invasive fix is to add a top‑level `permissions` block (so it applies to all jobs) near the top of `.github/workflows/update-submodule.yml`, below `name:` and before `on:`. This block should explicitly grant `contents: write` and `actions: write`. No other lines need modification; the existing steps can continue using `${{ secrets.GITHUB_TOKEN }}` with these scoped permissions. No additional imports or methods are required because this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
