### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     env:
       LYCHEE_INPUT_FILE: "links.txt"
       LYCHEE_OUTPUT_FILE: "lychee/out.md"


### PR DESCRIPTION
Potential fix for [https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/2](https://github.com/tldr-pages/tldr-maintenance/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block that grants only the minimum required scopes. The job needs to read repository contents (for checkout and actions) and manage issues (finding, creating/updating, and closing the “link checker report” issue). It does not appear to need write access to repository contents, workflows, or other scopes.

The best fix is to add a `permissions` block at the job level for `check-links`, immediately under `runs-on: ubuntu-latest`. This keeps other workflows/jobs unaffected and tightly documents what this job needs. The block should look like:

```yaml
permissions:
  contents: read
  issues: write
```

No imports or additional methods are needed; we’re only changing workflow configuration. This will ensure:
- `contents: read` allows `actions/checkout` and general repository reads.
- `issues: write` allows `micalevisk/last-issue-action`, `peter-evans/create-issue-from-file`, and `gh issue close` to function.

Line-wise, in `.github/workflows/check-links.yml`, between existing lines 15 and 16, insert the `permissions` block, adjusting indentation to align with the YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
