### PR TITLE
Fix dashboard update crashes and clean up empty report handling

### DIFF
--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -111,7 +111,7 @@ def create_colored_line(start_color: str, text: str) -> str:
     return f"{start_color}{text}{Colors.RESET}"
 
 
-def create_github_issue(title: str) -> list[dict]:
+def create_github_issue(title: str) -> dict:
     command = [
         "gh",
         "api",
@@ -129,7 +129,12 @@ def create_github_issue(title: str) -> list[dict]:
     result = subprocess.run(command, capture_output=True, text=True)
     data = json.loads(result.stdout)
 
-    return [{"number": data["number"], "title": data["title"], "url": data["html_url"]}]
+    return {
+        "number": data["number"],
+        "title": data["title"],
+        "body": data.get("body") or "",
+        "url": data["html_url"],
+    }
 
 
 def get_github_issue(title: str = None) -> list[dict]:
@@ -233,6 +238,8 @@ def strip_dynamic_content(markdown):
     Returns:
             str: The Markdown content with the dynamic content removed.
     """
+    if not markdown:
+        return ""
     regex = re.compile(
         r"<!--\s*__NOUPDATE__(.|\n)*__END_NOUPDATE__\s*-->", re.MULTILINE
     )

--- a/scripts/update-language-issues.py
+++ b/scripts/update-language-issues.py
@@ -48,7 +48,8 @@ class Topics(str, Enum):
 
 def parse_file(filepath):
     with filepath.open(encoding="utf-8") as file:
-        return file.read().strip().split("\n")
+        content = file.read().strip()
+        return content.split("\n") if content else []
 
 
 def parse_language_directory(directory):


### PR DESCRIPTION
- Fixes `create_github_issue()` returning a `list` instead of a `dict`, which raised a `TypeError` when adding new languages.
- Safe-guards `strip_dynamic_content()` from crashing with `TypeError: expected string or bytes-like object, got 'NoneType'` when an issue description/body on GitHub is empty (`None`).
- Fixes `parse_file()` returning `[""]` instead of `[]` for empty files, preventing the generation of corrupt empty markdown links (`- [](...)`).